### PR TITLE
fix: Pipeline build fails for features due to package name being invalid

### DIFF
--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -23,7 +23,7 @@ branches:
     tag: dev.{BranchName}
     source-branches: [main]
   feature:
-    tag: ^feature.{BranchName}
+    tag: feature.{BranchName}
     regex: feature/(.*?)
     source-branches: ['main']
     increment: none


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
Currently the pipelines fail to build due to the package name being invalid

## What is the new behavior?
Removed the character that is causing the error

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

