### PR TITLE
fix: stop requesting permission unless necessary

### DIFF
--- a/src/GeolocatorService.Shared/GeolocatorService.cs
+++ b/src/GeolocatorService.Shared/GeolocatorService.cs
@@ -101,6 +101,16 @@ namespace GeolocatorService
 
 		public async Task<bool> RequestPermission(CancellationToken ct)
 		{
+			// Requesting permission repeatedly is not necessary and can, for example,
+			// make the value emitted by the LocationPermissionChanged event become false for a short time
+			// when it was true, even thought the user never revoked the permissions.
+			var isPermissionGranted = await GetIsPermissionGranted(ct);
+
+			if (isPermissionGranted)
+			{
+				return true;
+			}
+
 			// Only subscribe to events here, not in the ctor, because subscribing to these
 			// Geolocator events causes the permission to be immediately requested and we want to allow
 			// greater flexibility with the moment the permission is requested.


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [X] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description
<!-- Please describe the changes that this PR introduces. -->
Fixed an issue where the permission value would become false when you did some operations like GetInitialLocationOrDefault because it would request permissions the value for the permission would become temporarily false. Also, repeatedly calling the api.


## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [X] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## PR Checklist 

- [X] Your conventional commits are aligned with the **Impact on version** section.
- [X] Documentation is up to date.
  - Content of `README.md` is up to date.
  - XML documentation is up to date.
- [ ] The [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) document is up to date.
  - Create a new Major.0.0 header if you do a **Major** change and list the breaking changes.
- [X] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->