### PR TITLE
chore: remove unused NuGet package Uno.SourceGenerationTasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 
 ### Removed
+* [2024-05-20] Removed NuGet package Uno.SourceGenerationTasks for WinUI.
 
 ### Fixed
 

--- a/src/GeolocatorService.Uno.WinUI/GeolocatorService.Uno.WinUI.csproj
+++ b/src/GeolocatorService.Uno.WinUI/GeolocatorService.Uno.WinUI.csproj
@@ -26,7 +26,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.WinUI" Version="5.0.19" />
-		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [x] Other, please describe:

## Description
<!-- Please describe the changes that this PR introduces. -->

Uno.SourceGenerationTasks is not referenced anymore for WinUI.

## Impact on version
<!-- Please select only one based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## PR Checklist 

- [x] Your conventional commits are aligned with the **Impact on version** section.
- [ ] Documentation is up to date.
  - Content of `README.md` is up to date.
  - XML documentation is up to date.
- [x] The [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) document is up to date.
  - Create a new Major.0.0 header if you do a **Major** change and list the breaking changes.
- [ ] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->